### PR TITLE
[CHORE]: 포크 리포지토리 동기화 스크립트 추가

### DIFF
--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -1,0 +1,35 @@
+name: Sync Fork
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    container: pandoc/latex
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install mustache
+        run: apk add ruby && gem install mustache
+
+      - name: creates output
+        run: sh ./build.sh
+
+      - name: Pushes to another repository
+        id: push_directory
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.AUTO_ACTIONS }}
+        with:
+          source-directory: 'output'
+          destination-github-username: ${{ secrets.FORK_OWNER }} # 개인 레포 소유자의 username
+          destination-repository-name: "WEB5_6_OneTop_FE" # 포크 뜬 개인 레포 이름
+          user-email: ${{ secrets.FORK_ACC }} # 개인 계정 이메일
+          commit-message: ${{ github.event.commits[0].message }}
+          target-branch: main # 개인 레포의 어느 브랜치에 복사할건지
+
+      - name: Test get variable exported by push-to-another-repository
+        run: echo $DESTINATION_CLONED_DIRECTORY

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+REPO_NAME="WEB5_6_OneTop_FE"
+
+cd ../
+
+mkdir output
+
+cp -R ./${REPO_NAME}/* ./output
+cp -R ./output ./${REPO_NAME}/


### PR DESCRIPTION
> **제목(필수)**: `[TYPE]: 제목`  예) `[FEAT]: 회원가입 기능 추가`
<details>
<summary>제목 규칙 자세히 보기</summary>

- 형식: `[TYPE]: 제목`
- 제한: **50자 이내**, 첫 글자 대문자, **명령문**
- TYPE: `FEAT` `FIX` `REFACTOR` `COMMENT` `STYLE` `TEST` `CHORE` `INIT`
</details>

---

## 무엇을 / 왜
- **무엇(What)**
  * 포크 리포지토리 동기화 스크립트 추가
- **왜(Why)**
  * vercel 의 경우 organization을 통한 vercel 배포 시 pro 이상의 요금제를 요구합니다.
  * 그래서 개인 repo로 포크 후 해당 repo에서 배포가 이루어지는데요.
  * 원본 리포지토리에 main 브랜치에 push 이벤트 발생 시 포크된 repo 쪽에도 자동으로 반영되게 하는 스크립트를 작성하여, 수동 갱신 없이도 자동으로 배포가 이루어지도록 구성했습니다.

## 어떻게(요약) — 3줄 이내
<!-- 핵심 변경점/설계 흐름/의존성 요약 -->
- 포크 리포지토리 동기화 스크립트 추가

## 영향 범위
- [ ] **API 변경**
- [ ] **DB 마이그레이션**
- [ ] **Breaking Change**
- [ ] **보안/권한 영향**
- [ ] 문서/가이드 업데이트 필요

## 체크리스트
- [x] 타입 라벨 부착 (FEAT/FIX/REFACTOR/COMMENT/STYLE/TEST/CHORE/INIT)
- [ ] 로컬/CI 테스트 통과
- [x] 영향도 점검 완료
- [x] 주석/문서 반영(필요 시)

## ToDo (선택)
- [ ] 오류발생 시 추가 수정


## 스크린샷/증빙(선택)
<!-- 이미지/로그 첨부 -->

## 이슈 연결 (자동)
<!-- 아래 라인은 액션이 자동으로 채웁니다. 직접 쓰지 마세요.
예: Cl0ses #123  (자동 주입)
-->

Closes #81
<!-- auto-linked-issue:81 -->